### PR TITLE
feat: add support for phabricator

### DIFF
--- a/src/constants/PRODUCT_TYPES.ts
+++ b/src/constants/PRODUCT_TYPES.ts
@@ -1,1 +1,7 @@
-export default ["github-v1", "github-v2", "gitlab-v1", "gitlab-v2"] as const;
+export default [
+  "github-v1",
+  "github-v2",
+  "gitlab-v1",
+  "gitlab-v2",
+  "phabricator-v1",
+] as const;

--- a/src/contentScript/Editor.svelte
+++ b/src/contentScript/Editor.svelte
@@ -264,6 +264,10 @@
     }
   }
 
+  .cc-select-wrapper-phabricator-v1 {
+    margin-bottom: 8px;
+  }
+
   /* Ensure there is enough place to show the full list */
   :global(textarea#note_note) {
     min-height: 188px;

--- a/src/contentScript/SelectItem.svelte
+++ b/src/contentScript/SelectItem.svelte
@@ -20,12 +20,14 @@
     "github-v2": "f5 text-bold",
     "gitlab-v1": "",
     "gitlab-v2": "",
+    "phabricator-v1": "cc-select-item-title-phabricator-v1",
   };
   const DESCRIPTION_CLASS: Record<ProductType, string> = {
     "github-v1": "text-small color-text-secondary text-normal pb-1",
     "github-v2": "text-small color-text-secondary text-normal pb-1",
     "gitlab-v1": "",
     "gitlab-v2": "",
+    "phabricator-v1": "",
   };
 </script>
 
@@ -97,6 +99,26 @@
           --bgColor-neutral-muted,
           var(--color-neutral-subtle)
         );
+      }
+    }
+
+    &.cc-select-item-phabricator-v1 {
+      color: var(--color-fg-default);
+      border: none;
+      font-weight: 200;
+      background-image: none;
+      background-color: transparent;
+      border-radius: 0;
+      box-shadow: none !important;
+      white-space: wrap;
+
+      &.cc-ext-hover,
+      &.cc-ext-active {
+        background: #eee;
+      }
+
+      & > .cc-select-item-title-phabricator-v1 {
+        font-weight: 600;
       }
     }
   }

--- a/src/contentScript/commentEditorExtractors/index.ts
+++ b/src/contentScript/commentEditorExtractors/index.ts
@@ -3,12 +3,14 @@ import gitlabV1 from "./gitlabCommentEditorExtractorV1";
 import gitlabV2 from "./gitlabCommentEditorExtractorV2";
 import githubV1 from "./githubCommentEditorExtractorV1";
 import githubV2 from "./githubCommentEditorExtractorV2";
+import phabricatorV1 from "./phabricatorCommentEditorExtractorV1";
 
 const commentEditorExtractors: CommentEditorExtractor[] = [
   gitlabV1,
   gitlabV2,
   githubV1,
   githubV2,
+  phabricatorV1,
 ];
 
 export default commentEditorExtractors;

--- a/src/contentScript/commentEditorExtractors/phabricatorCommentEditorExtractorV1.ts
+++ b/src/contentScript/commentEditorExtractors/phabricatorCommentEditorExtractorV1.ts
@@ -1,0 +1,103 @@
+import type { CommentEditorExtractor } from "./CommentEditorExtractor";
+
+const phabricatorCommentEditorExtractor: CommentEditorExtractor = (
+  generateId,
+  onTextareaExtracted,
+  onTextareaDisposed
+) => {
+  const extractedTextareas: {
+    id: string;
+    textarea: HTMLTextAreaElement;
+  }[] = [];
+
+  const handleNewTextarea = (node: Element) => {
+    node
+      .querySelectorAll(".differential-inline-comment-edit")
+      .forEach((parent) => {
+        const textarea = parent.querySelector(".remarkup-assist-textarea");
+        const buttonAnchorEl = parent.querySelector(
+          ".differential-inline-comment-edit-buttons"
+        );
+        const editorAnchorEl = parent.querySelector(
+          ".differential-inline-comment-edit-body"
+        );
+        if (
+          !(textarea instanceof HTMLTextAreaElement) ||
+          buttonAnchorEl === null ||
+          editorAnchorEl === null
+        ) {
+          return;
+        }
+
+        if (
+          extractedTextareas.some(
+            (extractedTextarea) => extractedTextarea.textarea === textarea
+          )
+        ) {
+          return;
+        }
+
+        const buttonTargetEl = buttonAnchorEl.parentElement;
+        const editorTargetEl = editorAnchorEl.parentElement;
+        if (buttonTargetEl === null || editorTargetEl === null) {
+          return;
+        }
+
+        const id = generateId();
+
+        onTextareaExtracted({
+          id,
+          isMainComment: parent.closest(".review-thread-reply") === null,
+          textarea,
+          buttonParams: {
+            target: buttonTargetEl,
+            anchor: buttonAnchorEl,
+          },
+          editorParams: {
+            target: editorTargetEl,
+            anchor: editorAnchorEl,
+          },
+          productType: "phabricator-v1",
+        });
+
+        extractedTextareas.push({
+          id,
+          textarea,
+        });
+      });
+  };
+
+  handleNewTextarea(document.body);
+  const mutationObserver = new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => {
+      if (mutation.type !== "childList") {
+        return;
+      }
+
+      mutation.addedNodes.forEach((node) => {
+        if (!(node instanceof Element)) {
+          return;
+        }
+        handleNewTextarea(node);
+      });
+
+      mutation.removedNodes.forEach((node) => {
+        const index = extractedTextareas.findIndex(({ textarea }) =>
+          node.contains(textarea)
+        );
+
+        if (index === -1) {
+          return;
+        }
+
+        const { id } = extractedTextareas[index];
+        extractedTextareas.splice(index, 1);
+        onTextareaDisposed(id);
+      });
+    });
+  });
+  mutationObserver.observe(document.body, { subtree: true, childList: true });
+  return mutationObserver.disconnect.bind(mutationObserver);
+};
+
+export default phabricatorCommentEditorExtractor;


### PR DESCRIPTION
**Overview**
This diff adds support for Phabricator into the conventional commits extension. The intention is to support using conventional comments for people still using [Phabricator](https://www.phacility.com/phabricator/). 

This change will likely have follow ups which improves styling and look and feel but the experience does line up with a somewhat expected look and feel. 

![image](https://github.com/user-attachments/assets/0d0b405d-185a-45b5-be9f-65ed827d13e6)

**Changes**
- Add query params for Phabricator elements
- Add custom styling for selection in Phabricator

**Notes**
I was unable to add a playwright test since Phabricator doesn't have any public instances available. Maybe I can add some kind of docker container to run an instance but I don't think it is worth the effort given the few users who have access to Phabricator.

