### PR TITLE
Fix GHES by selecting the comment form action bar

### DIFF
--- a/src/contentScript/commentEditorExtractors/githubCommentEditorExtractorV2.ts
+++ b/src/contentScript/commentEditorExtractors/githubCommentEditorExtractorV2.ts
@@ -45,16 +45,15 @@ const githubCommentEditorExtractor: CommentEditorExtractor = (
         if (mainEl === null) {
           return;
         }
-        const buttonAnchorEl = mainEl.querySelector(
-          "markdown-toolbar slash-command-toolbar-button"
-        );
         const editorAnchorEl = mainEl.querySelector("file-attachment");
-        if (buttonAnchorEl === null || editorAnchorEl === null) {
+        if (editorAnchorEl === null) {
           return;
         }
 
-        const buttonTargetEl = buttonAnchorEl.parentElement;
         const editorTargetEl = editorAnchorEl.parentElement;
+        const buttonTargetEl = mainEl.querySelector(
+          "action-bar .ActionBar-item-container"
+        );
         if (buttonTargetEl === null || editorTargetEl === null) {
           return;
         }
@@ -67,7 +66,6 @@ const githubCommentEditorExtractor: CommentEditorExtractor = (
           textarea,
           buttonParams: {
             target: buttonTargetEl,
-            anchor: buttonAnchorEl,
           },
           editorParams: {
             target: editorTargetEl,


### PR DESCRIPTION
…directly instead of finding the parent of the `slash-command-toolbar-button` — which doesn't exist on GHES, apparently. That parent would simply be the action-bar element!

This should fix GitHub Enterprise usage of the extension on GHES 3.13+.
