### PR TITLE
Resolve FIREFOX_EXTENSION_ID at zip time

### DIFF
--- a/mise.publish.toml
+++ b/mise.publish.toml
@@ -16,7 +16,12 @@ run = "pnpm wxt zip"
 
 [tasks."zip:firefox"]
 description = "Package the extension as a zip (Firefox)"
-run = "pnpm wxt zip -b firefox"
+# wxt.config.ts bakes FIREFOX_EXTENSION_ID into manifest.browser_specific_settings.gecko.id
+# at build time, so the op:// reference must be resolved before `wxt zip`
+# (not just at submit time) — otherwise AMO sees a manifest ID that
+# doesn't match the addon being submitted and rejects with
+# "Upload is not valid."
+run = "{{vars.op_run}} pnpm wxt zip -b firefox"
 
 [tasks."publish:chrome"]
 description = "Submit the packaged extension to the Chrome Web Store"


### PR DESCRIPTION
## Summary

- `zip:firefox` now uses `{{vars.op_run}}` so the 1password reference is resolved before `wxt zip -b firefox` reads `process.env.FIREFOX_EXTENSION_ID`.
- Without this, `wxt.config.ts:37` bakes the literal `op://…/EXTENSION_ID` string into `manifest.browser_specific_settings.gecko.id`, and AMO rejects the submit POST under the resolved addon GUID with `400 "Upload is not valid."` — that's the canary failure from the PR #69 merge to main ([run 27900949356](https://github.com/davidfou/conventionalcomments-web-extension/actions/runs/27900949356/job/82561043268)).

## Root cause

`wxt submit` uses `FIREFOX_EXTENSION_ID` as the target addon, but `wxt build` (run by `zip:firefox`) reads the SAME env var to populate the manifest's `gecko.id`. The old workflow had `1password/load-secrets-action` substitute the env block for the whole job, so both build and submit saw the GUID. After the mise migration only the `publish:*` tasks wrapped through `op run --`; `zip:*` ran with the env vars still holding op:// references.

## Repro / verification

Locally:
```bash
FIREFOX_EXTENSION_ID="op://example/path" mise exec -- pnpm wxt zip -b firefox
cat .output/firefox-mv3/manifest.json | jq '.browser_specific_settings.gecko.id'
# "op://example/path"   ← bug
```
After this fix the same task runs through `op run --`, so even on CI the value reaching `wxt` is the resolved GUID; chrome isn't affected because its extension ID lives in the CWS API, not the manifest.

## Test plan

- [x] `mise run lint` / `mise run build` still pass
- [ ] Merge → confirm `Release canary` workflow succeeds (publish-chrome already passes; publish-firefox should now too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)